### PR TITLE
update CI to use go 1.16 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,6 @@ on:
   push:
     branches:
       - main
-  schedule:
-    - cron: '0 0 * * *' # everyday
 defaults:
   run:
     shell: bash
@@ -19,27 +17,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - name: install Go
+        uses: actions/setup-go@v2
         with:
-          go-version: '1.15.x'
-      - name: install tip
-        run: |
-          git clone --depth=1 https://go.googlesource.com/go $HOME/gotip
-          cd $HOME/gotip/src
-          if [[ ${{ matrix.os }} == windows* ]]; then
-            ./make.bat
-          else
-            ./make.bash
-          fi
-          echo "GOROOT=$HOME/gotip" >> "$GITHUB_ENV"
-          echo "$HOME/gotip/bin" >> "$GITHUB_PATH"
+          go-version: 1.16.x
+      - name: checkout code
+        uses: actions/checkout@v2
       - name: golangci-lint
-        run: |
-          if [[ ${{ matrix.os }} != windows* ]]; then
-            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.33.0
-            golangci-lint run -v ./...
-          fi
+        if: matrix.os != 'windows-latest'
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.36
       - name: go test
         run: |
           go version


### PR DESCRIPTION
Since go 1.16 is officially out now, there is no more need to get the latest build from tip.